### PR TITLE
Hook Location.isMock() on API level 31+

### DIFF
--- a/app/src/main/java/com/github/thepiemonster/hidemocklocation/XposedModule.java
+++ b/app/src/main/java/com/github/thepiemonster/hidemocklocation/XposedModule.java
@@ -1,6 +1,7 @@
 package com.github.thepiemonster.hidemocklocation;
 
 import android.content.ContentResolver;
+import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
 
@@ -111,9 +112,14 @@ public class XposedModule implements IXposedHookZygoteInit, IXposedHookLoadPacka
                 hideMockGooglePlayServicesHook.init(lpparam.processName, lpparam.packageName));
 
         // New way of checking if location is mocked, SDK 18+
+        // deprecated in API level 31
         if (Common.JB_MR2_NEWER)
             XposedHelpers.findAndHookMethod("android.location.Location", lpparam.classLoader,
                     "isFromMockProvider", hideMockProviderHook.init(lpparam.processName, lpparam.packageName));
+
+        if (Build.VERSION.SDK_INT >= 31)
+            XposedHelpers.findAndHookMethod("android.location.Location", lpparam.classLoader,
+                    "isMock", hideMockProviderHook.init(lpparam.processName, lpparam.packageName));
 
         // Self hook - informing Activity that Xposed module is enabled
         if(lpparam.packageName.equals(Common.PACKAGE_NAME))


### PR DESCRIPTION
Location.isFromMockProvider() is deprecated in API level 31 and Location.isMock() is the replacement.